### PR TITLE
Add basic coherence-field stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # LCFT
 The L'Varian Coherence Field Theory
+
+This repository contains basic stubs for the coherence-field implementation. The `src/` directory provides
+simple C++ classes:
+
+- `Point` – a lightweight 2D point structure shared across the codebase.
+- `CoherenceField` – represents a coherence field and exposes a method to sample the field at a point.
+- `AdaptiveMesh` – maintains a set of mesh nodes and allows refinement around a given point.
+- `SystemMatrices` – stores matrices used by the simulation in a flattened form.
+
+These files serve as a starting point for further development.

--- a/src/AdaptiveMesh.cpp
+++ b/src/AdaptiveMesh.cpp
@@ -1,0 +1,8 @@
+#include "AdaptiveMesh.h"
+
+AdaptiveMesh::AdaptiveMesh(int resolution) : resolution(resolution) {}
+
+void AdaptiveMesh::refineAround(const Point& p) {
+    // Placeholder implementation - just store the point
+    meshNodes.push_back(p);
+}

--- a/src/AdaptiveMesh.h
+++ b/src/AdaptiveMesh.h
@@ -1,0 +1,17 @@
+#ifndef LCFT_ADAPTIVE_MESH_H
+#define LCFT_ADAPTIVE_MESH_H
+
+#include "Point.h"
+#include <vector>
+
+class AdaptiveMesh {
+public:
+    AdaptiveMesh(int resolution);
+    void refineAround(const Point& p);
+    const std::vector<Point>& nodes() const { return meshNodes; }
+private:
+    int resolution;
+    std::vector<Point> meshNodes; // placeholder for mesh nodes
+};
+
+#endif // LCFT_ADAPTIVE_MESH_H

--- a/src/CoherenceField.cpp
+++ b/src/CoherenceField.cpp
@@ -1,0 +1,8 @@
+#include "CoherenceField.h"
+
+CoherenceField::CoherenceField() {}
+
+double CoherenceField::valueAt(const Point& p) const {
+    // Placeholder implementation
+    return p.x + p.y;
+}

--- a/src/CoherenceField.h
+++ b/src/CoherenceField.h
@@ -1,0 +1,15 @@
+#ifndef LCFT_COHERENCE_FIELD_H
+#define LCFT_COHERENCE_FIELD_H
+
+#include "Point.h"
+#include <vector>
+
+class CoherenceField {
+public:
+    CoherenceField();
+    double valueAt(const Point& p) const;
+private:
+    std::vector<double> fieldValues; // placeholder for field data
+};
+
+#endif // LCFT_COHERENCE_FIELD_H

--- a/src/Point.h
+++ b/src/Point.h
@@ -1,0 +1,9 @@
+#ifndef LCFT_POINT_H
+#define LCFT_POINT_H
+
+struct Point {
+    double x;
+    double y;
+};
+
+#endif // LCFT_POINT_H

--- a/src/SystemMatrices.cpp
+++ b/src/SystemMatrices.cpp
@@ -1,0 +1,11 @@
+#include "SystemMatrices.h"
+
+SystemMatrices::SystemMatrices(int size) : size(size), data(size*size, 0.0) {}
+
+double SystemMatrices::getValue(int i, int j) const {
+    return data[i*size + j];
+}
+
+void SystemMatrices::setValue(int i, int j, double value) {
+    data[i*size + j] = value;
+}

--- a/src/SystemMatrices.h
+++ b/src/SystemMatrices.h
@@ -1,0 +1,16 @@
+#ifndef LCFT_SYSTEM_MATRICES_H
+#define LCFT_SYSTEM_MATRICES_H
+
+#include <vector>
+
+class SystemMatrices {
+public:
+    SystemMatrices(int size);
+    double getValue(int i, int j) const;
+    void setValue(int i, int j, double value);
+private:
+    int size;
+    std::vector<double> data; // flattened matrix
+};
+
+#endif // LCFT_SYSTEM_MATRICES_H


### PR DESCRIPTION
## Summary
- add `src/` folder for the coherence-field implementation
- implement `Point` struct in a single header and use it in all classes
- add stub classes `CoherenceField`, `AdaptiveMesh`, and `SystemMatrices`
- update README with descriptions of the new classes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683b24e168a083259ec50f1534fcf4ab